### PR TITLE
introduce BltMemcpy which is faster than the SSSE3 version

### DIFF
--- a/SSE Hand Relief Very Nice/Surface.h
+++ b/SSE Hand Relief Very Nice/Surface.h
@@ -560,6 +560,26 @@ public:
 			}
 		}
 	}
+	void BltMemcpy(Vei2 dstPt, const RectI& srcRect, const Surface& src)
+	{
+		const Color* __restrict ptSrc = src.GetBufferConst();
+		Color* __restrict ptDst = GetBuffer();
+
+		ptSrc += srcRect.top * src.GetWidth() + srcRect.left;
+		ptDst += dstPt.y * GetWidth() + dstPt.x;
+
+		Color* ptDstEnd = ptDst + srcRect.GetHeight() * GetWidth();
+
+		const int rowByteSize = srcRect.GetWidth() * sizeof(Color);
+
+		while (ptDst < ptDstEnd)
+		{
+			::memcpy(ptDst, ptSrc, rowByteSize);
+
+			ptDst += GetWidth();
+			ptSrc += src.GetWidth();
+		}
+	}
 	void BltBlend( Vei2 dstPt,const RectI& srcRect,const Surface& src,unsigned char alpha )
 	{
 		const unsigned int mask = 0xFF;


### PR DESCRIPTION
I had the gut feeling that a memcpy per row might be faster so I cloned this repo and added it. I used 100 rects on a Core i7 4790K

Blt

Avg: [7.835] Min: [7.047] Max: [8.504]
Avg: [7.361] Min: [6.961] Max: [8.145]
Avg: [7.828] Min: [7.004] Max: [9.231]
Avg: [9.299] Min: [7.727] Max: [13.588]
Avg: [8.719] Min: [7.062] Max: [16.546]
Avg: [10.013] Min: [7.631] Max: [18.454]
Avg: [8.874] Min: [7.228] Max: [17.036]
Avg: [9.361] Min: [6.937] Max: [21.657]
Avg: [10.841] Min: [7.687] Max: [22.414]
Avg: [8.602] Min: [7.091] Max: [13.499]

BltSSSE3

Avg: [6.073] Min: [4.885] Max: [10.007]
Avg: [5.144] Min: [4.924] Max: [5.545]
Avg: [5.371] Min: [4.895] Max: [6.674]
Avg: [5.323] Min: [4.936] Max: [6.114]
Avg: [6.152] Min: [4.955] Max: [15.131]
Avg: [6.227] Min: [4.756] Max: [10.521]
Avg: [9.020] Min: [4.820] Max: [17.652]
Avg: [8.615] Min: [5.173] Max: [21.373]
Avg: [5.331] Min: [5.053] Max: [6.175]
Avg: [5.221] Min: [5.032] Max: [5.803]
Avg: [5.174] Min: [5.014] Max: [5.633]
Avg: [7.533] Min: [5.039] Max: [19.944]
Avg: [5.913] Min: [5.032] Max: [17.071]
Avg: [7.235] Min: [5.016] Max: [15.804]

BltMemcpy

Avg: [4.698] Min: [4.291] Max: [5.739]
Avg: [9.392] Min: [4.332] Max: [13.460]
Avg: [4.725] Min: [4.386] Max: [7.635]
Avg: [5.369] Min: [4.399] Max: [9.170]
Avg: [5.667] Min: [4.430] Max: [11.666]
Avg: [5.145] Min: [4.464] Max: [6.154]
Avg: [4.562] Min: [4.241] Max: [5.086]
Avg: [4.776] Min: [4.252] Max: [5.420]
Avg: [4.572] Min: [4.363] Max: [5.088]
Avg: [5.860] Min: [4.471] Max: [12.802]